### PR TITLE
Allow nodes with `nil` key to get merged into main

### DIFF
--- a/lib/rabl-rails/renderers/base.rb
+++ b/lib/rabl-rails/renderers/base.rb
@@ -83,7 +83,13 @@ module RablRails
             end
             next output
           end
-          output[key] = out
+  
+          if key.nil?
+            output.merge!(out)
+          else
+            output[key] = out
+          end
+          
           output
         }
       end


### PR DESCRIPTION
This is like calling `extends` but changing the inner object.

Example:

``` ruby
collection :@child_objects

node(nil) { |child_object| partial 'parents_detail', object: child_object.my_parent }
```
