### PR TITLE
Fix empty template source

### DIFF
--- a/lib/rabl-rails/library.rb
+++ b/lib/rabl-rails/library.rb
@@ -30,7 +30,8 @@ module RablRails
       template = @cached_templates[path]
       return template if template
       t = @lookup_context.find_template(path, [], false)
-      compile_template_from_source(t.source, path)
+      source = t.source || File.binread(t.identifier)
+      compile_template_from_source(source, path)
     end
   end
 end


### PR DESCRIPTION
When rails compiles a template, it nils-out it's source.
For most (normal) requests this does not matter, but when running a bunch of tests this may happen (at least to me)
