### PR TITLE
Fix `glue` to support full template stack

### DIFF
--- a/lib/rabl-rails/renderers/base.rb
+++ b/lib/rabl-rails/renderers/base.rb
@@ -70,9 +70,7 @@ module RablRails
             end
 
             if key.to_s.start_with?('_') # glue
-              current_value.each_pair { |k, v|
-                output[k] = object.send(v)
-              }
+              output.merge!(render_resource(object, current_value))
               next output
             else # child
               object.respond_to?(:each) ? render_collection(object, current_value) : render_resource(object, current_value)


### PR DESCRIPTION
The current implementation of `glue` support the glued content to use attributes only. So `glue` should basically do the same thing as `child` (except supporting collections) but merge the result into the parent object instead of injecting it at a given key.   
