### PR TITLE
Add JSONP support

### DIFF
--- a/lib/rabl-rails.rb
+++ b/lib/rabl-rails.rb
@@ -21,6 +21,9 @@ module RablRails
 
   autoload :Responder, 'rabl-rails/responder'
 
+  mattr_accessor :render_jsonp_callback
+  @@render_jsonp_callback = true
+  
   mattr_accessor :cache_templates
   @@cache_templates = true
 

--- a/lib/rabl-rails/renderers/json.rb
+++ b/lib/rabl-rails/renderers/json.rb
@@ -3,7 +3,11 @@ module RablRails
     class JSON < Base
       def format_output(hash)
         hash = { _options[:root_name] => hash } if _options[:root_name] && RablRails.include_json_root
-        MultiJson.encode(hash)
+        if RablRails.render_jsonp_callback && params["callback"]
+          "#{params["callback"]}(#{MultiJson.encode(hash)})"
+        else
+          MultiJson.encode(hash)
+        end
       end
     end
   end


### PR DESCRIPTION
So that async requests can be used as a callback, you call pass a params["callback"] and it returns a valid JSONP response.
