### PR TITLE
Fix tests on Ruby 2 by changing how minitest is required.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,12 +2,18 @@ ENV["RAILS_ENV"] = "test"
 $:.unshift File.expand_path('../../lib', __FILE__)
 
 require 'rspec/mocks'
-require 'minitest/autorun'
+
+# minitest mocks conflict with rspec/mocks, requiring minitest/autorun require minitest/mocks, so dont.
+require 'minitest/unit'
+require 'minitest/spec'
+MiniTest::Unit.autorun
+
 require 'active_support/test_case'
 
 require 'action_controller'
 
 require 'singleton'
+
 class <<Singleton
   def included_with_reset(klass)
     included_without_reset(klass)


### PR DESCRIPTION
Tests fail with Ruby 2.0 due to an apparent conflict between rspec/mocks and minitest/mocks. Changing how minitest is required fixes the issues and causes tests to pass.
