### PR TITLE
Simplify Finding Templates

### DIFF
--- a/lib/rabl-rails/renderer.rb
+++ b/lib/rabl-rails/renderer.rb
@@ -39,12 +39,7 @@ module RablRails
           nil
         end
       end
-      # How it looked before.
-      # def find_template(name, opt, partial = false)
-      #   path = File.join(@view_path, "#{name}.#{@format}.rabl")
-      #   File.exists?(path) ? T.new(File.read(path)) : nil
-      # end
-      end
+    end
 
     #
     # Context class to emulate normal Rails view


### PR DESCRIPTION
We were running into problems in RSPEC because you would have to specify the format as well as the path when testing templates. 

This allows you to create a path without having to specify a format. 
