### PR TITLE
Allow For Path Without Format

### DIFF
--- a/lib/rabl-rails/renderer.rb
+++ b/lib/rabl-rails/renderer.rb
@@ -24,8 +24,17 @@ module RablRails
       # path is used
       #
       def find_template(name, opt, partial = false)
-        path = File.join(@view_path, "#{name}.#{@format}.rabl")
-        File.exists?(path) ? T.new(File.read(path)) : nil
+        path = File.join(@view_path, "#{name}.rabl")
+        path_with_format = File.join(@view_path, "#{name}.#{@format}.rabl")
+
+        case
+        when File.exists?(path) then
+          T.new(File.read(path))
+        when File.exists?(path_with_format) then
+          T.new(File.read(path_with_format))
+        else
+          nil
+        end
       end
     end
 


### PR DESCRIPTION
This change allows you to specify a path without putting a format (i.e. JSON, XML..). We are making this change because when you specify a format was giving us problems with RSPEC. 
