### PR TITLE
Adds Rails 3.0 compatibility

### DIFF
--- a/lib/rabl-rails/renderers/base.rb
+++ b/lib/rabl-rails/renderers/base.rb
@@ -162,6 +162,8 @@ module RablRails
       # evaluating 'node' properties.
       #
       def setup_render_context
+        # Rails 3.0.x use @assigns, @_assings appears in 3.1 branch, see https://github.com/rails/rails/commit/49b6f33f99a28d68f18203a696fb47854a9085d2
+        @_context.instance_variable_set(:@_assigns, @_context.instance_variable_get(:@assigns))
         @_context.instance_variable_get(:@_assigns).each_pair { |k, v|
           instance_variable_set("@#{k}", v) unless k.to_s.start_with?('_')
         }

--- a/rabl-rails.gemspec
+++ b/rabl-rails.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- test/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency "activesupport", ">= 3.1"
-  s.add_dependency "railties", ">= 3.1"
+  s.add_dependency "activesupport", ">= 3.0"
+  s.add_dependency "railties", ">= 3.0"
+  s.add_dependency 'multi_json', '~> 1.0'
 
-  s.add_development_dependency "actionpack", ">= 3.1"
+  s.add_development_dependency "actionpack", ">= 3.0"
   s.add_development_dependency "rspec-mocks"
 end


### PR DESCRIPTION
Since Rails 3.1 the internal name for "assigns" has changed. Anyway, Rails 3.0 compatibility was already broken by some dependencies for the Gem.

Since there are no tests for this kind of problem, I don't knew where to add this tests.

Please contact me if you have any concern about it.
