### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,14 @@ RablRails.configure do |config|
   # These are the default
   # config.cache_templates = true
   # config.include_json_root = true
-  # config.json_engine = :oj
+  # config.json_engine = ::Oj
   # config.xml_options = { :dasherize => true, :skip_types => false }
   # config.use_custom_responder = false
   # config.default_responder_template = 'show'
   # config.enable_jsonp_callbacks = false
+  # config.replace_nil_values_with_empty_strings = false
+  # config.replace_empty_string_values_with_nil = false
+  # config.exclude_nil_values = false
 end
 ```
 


### PR DESCRIPTION
Above all json_engine now takes a Module instead of a Symbol
