### PR TITLE
Adding 'Enumerable' to collection criteria

### DIFF
--- a/lib/rabl-rails/helpers.rb
+++ b/lib/rabl-rails/helpers.rb
@@ -3,7 +3,7 @@ module RablRails
     def collection?(resource)
       klass = resource.class
 
-      resource && resource.respond_to?(:each) &&
+      resource && resource.respond_to?(:each) && resource.kind_of?(Enumerable) &&
         klass.ancestors.none? { |a| RablRails.configuration.non_collection_classes.include? a.name }
     end
   end

--- a/lib/rabl-rails/renderer.rb
+++ b/lib/rabl-rails/renderer.rb
@@ -27,7 +27,7 @@ module RablRails
       #
       def find_template(name, opt, partial = false)
         paths = Dir["#@view_path/#{name}{.#@format,}.rabl"]
-        file_path = paths.find { |path| File.exists?(path) }
+        file_path = paths.find { |path| File.exist?(path) }
 
         if file_path
           T.new(File.read(file_path))

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -9,15 +9,15 @@ class TestHelpers < MINITEST_TEST_CLASS
     refute collection?(User.new(1))
   end
 
-  NotACollection = Class.new do
+  ACollection = Class.new(Array) do
     def each; end
   end
 
   def test_collection_with_configuration
-    assert collection?(NotACollection.new)
+    assert collection?(ACollection.new)
 
-    with_configuration(:non_collection_classes, Set.new(['Struct', 'TestHelpers::NotACollection'])) do
-      refute collection?(NotACollection.new), 'NotACollection triggers #collection?'
+    with_configuration(:non_collection_classes, Set.new(['Struct', 'TestHelpers::ACollection'])) do
+      refute collection?(ACollection.new), 'Collection triggers #collection?'
     end
   end
 end


### PR DESCRIPTION
I made this modification to help resolve an issue I was having with my models. They respond to ```#each```, but having them treated as a collection was breaking my views.

I added the ```Enumerable``` condition since most items that might be iterated on probably inherit from it at some point. Adding it before the ```non_collection_classes``` allows it to exit before checking the blacklist (which saves time, I know this was a concern in #55). Leaving in the blacklist lets us disallow any classes that might still cause problems.

Please let me know what you think. 