### PR TITLE
rabl-rails with rails 5 in api mode

### DIFF
--- a/lib/rabl-rails/railtie.rb
+++ b/lib/rabl-rails/railtie.rb
@@ -6,6 +6,21 @@ module RablRails
       end
     end
 
+    if Rails::VERSION::MAJOR >= 5
+      module ::ActionController
+        module ApiRendering
+          include ActionView::Rendering
+        end
+      end
+
+      ActiveSupport.on_load :action_controller do
+        if self == ActionController::API
+          include ActionController::Helpers
+          include ActionController::ImplicitRender
+        end
+      end
+    end
+
     config.after_initialize do
       ActionController::Base.responder = RablRails::Responder if RablRails.configuration.use_custom_responder
     end


### PR DESCRIPTION
I had an issue with rabl-rails in combination with ActionController::API. As a request response, i had a 204 status with no content. During the research, i figured out that ActionController::API don't have ActionController::Helpers and ActionController::ImplicitRender in ancestors. So I decided to add it.
If it is not proper behaviour for the gem, maybe it gonna be better at least to add a wiki page for such ones like me?