### PR TITLE
Allow concurrent-ruby 1.x releases

### DIFF
--- a/rabl-rails.gemspec
+++ b/rabl-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', '>= 4.2'
   s.add_dependency 'railties', '>= 4.2'
-  s.add_dependency 'concurrent-ruby', '~> 1.0.0'
+  s.add_dependency 'concurrent-ruby', '~> 1.0'
 
   s.add_development_dependency 'actionpack', '>= 4.2'
   s.add_development_dependency 'actionview', '>= 4.2'


### PR DESCRIPTION
This matches what is in several other common Rails dependencies too.