### PR TITLE
Quick Rails 6 deprecation warning fixes

### DIFF
--- a/lib/rabl-rails/handler.rb
+++ b/lib/rabl-rails/handler.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/class/attribute'
 module RablRails
   module Handlers
     class Rabl
-      def self.call(template)
+      def self.call(template, source = nil)
         %{
           RablRails::Library.instance.
             get_rendered_template(#{template.source.inspect}, self, local_assigns)

--- a/lib/rabl-rails/library.rb
+++ b/lib/rabl-rails/library.rb
@@ -25,7 +25,7 @@ module RablRails
 
     def get_rendered_template(source, view, locals = nil)
       compiled_template = compile_template_from_source(source, view)
-      format = view.lookup_context.rendered_format || :json
+      format = view.request.format.symbol || :json
       raise UnknownFormat, "#{format} is not supported in rabl-rails" unless RENDERER_MAP.key?(format)
       RENDERER_MAP[format].render(compiled_template, view, locals)
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -44,23 +44,23 @@ module ActionController
 end
 
 class Context
-  class LookupContext
+  class Request
     def initialize(format)
       @format = format
     end
 
-    def rendered_format
-      @format.to_sym
+    def format
+      OpenStruct.new(symbol: @format.to_sym)
     end
   end
 
   attr_writer :virtual_path
-  attr_reader :lookup_context
+  attr_reader :request
 
   def initialize(format = :json)
     @_assigns = {}
     @virtual_path = nil
-    @lookup_context = LookupContext.new(format)
+    @request = Request.new(format)
   end
 
   def assigns


### PR DESCRIPTION
Hello Christopher,

thank you for `rabl-rails`.

Here quick & dirty proposed changes to silence Rails 6 deprecation warnings. Haven't tested these on Rails 5.

Kind regards