### PR TITLE
Add a `condition` block example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,14 @@ node(:email, if: ->(u) { u.valid_email? }) do |u|
 end
 ```
 
+You can also use a condition block. These can be used with `node`, `extends`, etc.
+
+```ruby
+condition(->(u) { u.admin? }) do
+  attributes :secret
+end
+```
+
 Nodes are evaluated at rendering time, so you can use any instance variables or view helpers within them
 
 ```ruby


### PR DESCRIPTION
This is something we noticed that is a public and documented method that proved to be really helpful but is not included in the examples in the README file. We needed to conditionally extend a partial for one case, and then another condition (the inverse of the previous) to extend a different partial. I just [used the example already listed in source](https://github.com/ccocchi/rabl-rails/blob/12c7103432f734acff949d514045194b408d9736/lib/rabl-rails/compiler.rb#L169-L180).